### PR TITLE
Desarrollo back: modificar y eliminar tareas; modificar cursos

### DIFF
--- a/public/assignments/delete_assignment.php
+++ b/public/assignments/delete_assignment.php
@@ -1,0 +1,73 @@
+<?php
+
+// Configurar el encabezado HTTP como JSON para el intercambio de datos
+header('Content-Type: application/json');
+
+// Iniciar la sesión
+session_start();
+// Verificar el rol del usuario para permitir la eliminación de tareas (solo 'admin' o 'master')
+if (!isset($_SESSION['user_role']) || ($_SESSION['user_role'] != 'admin' && $_SESSION['user_role'] != 'master')) {
+    // Si el usuario no tiene los roles permitidos, redirigirlo a la página principal y salir
+    header("Location: ../index.php");
+    exit();
+}
+
+// Incluir el archivo de conexión a la base de datos
+include "../modelo/conexion.php";
+
+// Verificar si la solicitud HTTP es de tipo POST
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    // Obtener el cuerpo de la petición en formato JSON
+    $request = json_decode(file_get_contents("php://input"));
+
+    // Verificar si se ha proporcionado el 'assignmentId' en la petición
+    if (isset($request->assignmentId)) {
+        // Obtener el ID de la tarea desde la petición
+        $assignmentId = $request->assignmentId;
+
+        // Preparar la consulta SQL para eliminar la tarea
+        $deleteAssignmentSql = "DELETE FROM assignments WHERE assignment_id = ?";
+        $deleteAssignmentStmt = $conn->prepare($deleteAssignmentSql);
+
+        // Vincular el parámetro ID a la consulta preparada
+        // 'i' indica que el parámetro es de tipo entero
+        $deleteAssignmentStmt->bind_param('i', $assignmentId);
+
+        // Ejecutar la consulta
+        if ($deleteAssignmentStmt->execute()) {
+            // Si la eliminación fue exitosa, preparar una respuesta JSON indicándolo
+            $response = [
+                "isAssignmentDeleted" => true,
+                "message" => "Tarea eliminada exitosamente."
+            ];
+        } else {
+            // Si hubo un error al ejecutar la consulta, preparar una respuesta JSON con un mensaje de error
+            $response = [
+                "isAssignmentDeleted" => false,
+                "message" => "Error al eliminar la tarea: " . $deleteAssignmentStmt->error
+            ];
+        }
+
+        // Cerrar la declaración preparada
+        $deleteAssignmentStmt->close();
+    } else {
+        // Si 'assignmentId' no fue proporcionado en la petición, preparar una respuesta de error
+        $response = [
+            "isAssignmentDeleted" => false,
+            "message" => "El 'assignmentId' no fue proporcionado en la solicitud."
+        ];
+    }
+
+    // Devolver la respuesta en formato JSON
+    echo json_encode($response);
+} else {
+    // Si la solicitud no es POST, devolver un error indicando que solo se permite POST
+    $response = [
+        "isAssignmentDeleted" => false,
+        "message" => "Método de solicitud no permitido. Solo se acepta POST."
+    ];
+    echo json_encode($response);
+}
+
+// Cerrar la conexión a la base de datos (opcional, PHP la cierra automáticamente al finalizar el script)
+$conn->close();

--- a/public/assignments/modify_assignment.php
+++ b/public/assignments/modify_assignment.php
@@ -1,0 +1,116 @@
+<?php
+
+// Configurar el encabezado HTTP como JSON para el intercambio de datos
+header('Content-Type: application/json');
+
+// Iniciar la sesión
+session_start();
+if (!isset($_SESSION['user_role']) || ($_SESSION['user_role'] != 'admin' && $_SESSION['user_role'] != 'master')) {
+    header("Location: ../index.php");
+    exit();
+}
+
+include "../modelo/conexion.php"; // Asegúrate de que esta ruta sea correcta para tu conexión a la DB
+
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    // Obtener el objeto de la petición en formato JSON
+    $request = json_decode(file_get_contents("php://input"));
+
+    // Validar que se ha proporcionado un ID para la tarea a modificar
+    if (!isset($request->assignmentId)) {
+        echo json_encode(["success" => false, "message" => "El ID de la tarea es requerido para la modificación."]);
+        exit();
+    }
+
+    $assignmentId = $request->assignmentId;
+    $assignmentName = $request->assignmentName ?? null; // Usar null coalescing para campos opcionales
+    $assignmentDescription = $request->assignmentDescription ?? null;
+    $assignmentMaxScore = $request->assignmentMaxScore ?? null;
+    $assignmentSubmissionDate = $request->assignmentSubmissionDate ?? null;
+    $assignmentSubmissionTime = $request->assignmentSubmissionTime ?? null;
+    $topic = $request->topic ?? null;
+
+    // Construir dinámicamente la consulta UPDATE
+    $updateFields = [];
+    $bindParams = [];
+    $bindTypes = '';
+
+    if ($assignmentName !== null) {
+        $updateFields[] = "assignment_name = ?";
+        $bindParams[] = $assignmentName;
+        $bindTypes .= 's';
+    }
+    if ($assignmentDescription !== null) {
+        $updateFields[] = "assignment_description = ?";
+        $bindParams[] = $assignmentDescription;
+        $bindTypes .= 's';
+    }
+    if ($assignmentMaxScore !== null) {
+        $updateFields[] = "max_score = ?";
+        $bindParams[] = $assignmentMaxScore;
+        $bindTypes .= 'i';
+    }
+    if ($assignmentSubmissionDate !== null) {
+        $updateFields[] = "submission_date = ?";
+        $bindParams[] = $assignmentSubmissionDate;
+        $bindTypes .= 's';
+    }
+    if ($assignmentSubmissionTime !== null) {
+        $updateFields[] = "submission_time = ?";
+        $bindParams[] = $assignmentSubmissionTime;
+        $bindTypes .= 's';
+    }
+    if ($topic !== null) {
+        $updateFields[] = "topic = ?";
+        $bindParams[] = $topic;
+        $bindTypes .= 'i';
+    }
+
+    // Verificar si hay campos para actualizar
+    if (empty($updateFields)) {
+        echo json_encode(["success" => false, "message" => "No se proporcionaron campos para actualizar."]);
+        exit();
+    }
+
+    $updateAssignmentSql = "UPDATE assignments SET " . implode(", ", $updateFields) . " WHERE id = ?";
+
+    // Añadir el ID al final de los parámetros de enlace
+    $bindParams[] = $assignmentId;
+    $bindTypes .= 'i'; // El ID es un entero
+
+    $updateAssignmentStmt = $conn->prepare($updateAssignmentSql);
+
+    // Unir los parámetros dinámicamente
+    // Aquí es crucial usar '...' para desempaquetar el array de parámetros
+    if (!empty($bindParams)) {
+        $updateAssignmentStmt->bind_param($bindTypes, ...$bindParams);
+    }
+
+
+    if ($updateAssignmentStmt->execute()) {
+        if ($updateAssignmentStmt->affected_rows > 0) {
+            $response = [
+                "success" => true,
+                "message" => "Tarea actualizada exitosamente."
+            ];
+        } else {
+            $response = [
+                "success" => false,
+                "message" => "No se encontró la tarea con el ID proporcionado o no hubo cambios para aplicar."
+            ];
+        }
+    } else {
+        $response = [
+            "success" => false,
+            "message" => "Error al actualizar la tarea: " . $updateAssignmentStmt->error
+        ];
+    }
+
+    echo json_encode($response);
+} else {
+    // Si la solicitud no es POST, se podría manejar aquí (ej. devolver un error)
+    echo json_encode(["success" => false, "message" => "Método de solicitud no permitido. Usa POST para esta operación."]);
+}
+
+// Cerrar la conexión
+$conn->close();

--- a/public/courses/modify_course.php
+++ b/public/courses/modify_course.php
@@ -1,0 +1,89 @@
+<?php
+
+// Configurar el encabezado HTTP como JSON para el intercambio de datos
+header('Content-Type: application/json');
+
+// Iniciar la sesion
+session_start();
+
+// Verificar si el usuario ha iniciado sesion y tiene el rol adecuado
+if (!isset($_SESSION['user_role']) || ($_SESSION['user_role'] != 'admin' && $_SESSION['user_role'] != 'master')) {
+    header("Location: ../index.php"); // Redirigir si no tiene permisos
+    exit();
+}
+
+// Incluir la conexion a la base de datos
+include "../modelo/conexion.php";
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // Obtener el objeto de la peticion en formato JSON
+    $request = json_decode(file_get_contents("php://input"));
+
+    // Validar que los datos necesarios estan presentes
+    if (!isset($request->courseId) || !isset($request->courseName) || !isset($request->courseDescription)) {
+        $response = [
+            "isCourseUpdated" => false,
+            "msg" => "Faltan datos obligatorios para actualizar el curso."
+        ];
+        echo json_encode($response);
+        exit();
+    }
+
+    // Obtener los datos del curso a actualizar
+    $courseId = (int) $request->courseId; // Asegurarse de que sea un entero
+    $courseName = trim($request->courseName);
+    $courseDescription = trim($request->courseDescription);
+    // Opcionalmente, puedes anadir mas campos para modificar, como el ID del profesor, etc.
+
+    // Consulta SQL para actualizar el curso
+    $sql = "UPDATE courses SET course_name = ?, course_description = ? WHERE course_id = ?";
+    $stmt = $conn->prepare($sql);
+
+    // Verificar si la preparacion de la consulta fue exitosa
+    if ($stmt === false) {
+        $response = [
+            "isCourseUpdated" => false,
+            "msg" => "Error al preparar la consulta de actualizacion: " . $conn->error
+        ];
+        echo json_encode($response);
+        exit();
+    }
+
+    // Vincular los parametros a la consulta
+    $stmt->bind_param("ssi", $courseName, $courseDescription, $courseId);
+
+    // Ejecutar la consulta
+    if ($stmt->execute()) {
+        // Verificar si se afectaron filas (si se actualizo el curso)
+        if ($stmt->affected_rows > 0) {
+            $response = [
+                "isCourseUpdated" => true,
+                "msg" => "Curso actualizado correctamente."
+            ];
+        } else {
+            $response = [
+                "isCourseUpdated" => false,
+                "msg" => "No se realizaron cambios o el curso no existe."
+            ];
+        }
+    } else {
+        $response = [
+            "isCourseUpdated" => false,
+            "msg" => "Error al actualizar el curso: " . $stmt->error
+        ];
+    }
+
+    // Cerrar la declaracion
+    $stmt->close();
+    // Cerrar la conexion (opcional, si no se realizan mas operaciones)
+    $conn->close();
+
+    echo json_encode($response);
+} else {
+    // Si la solicitud no es POST, devolver un error
+    $response = [
+        "isCourseUpdated" => false,
+        "msg" => "Metodo de solicitud no permitido."
+    ];
+    echo json_encode($response);
+}


### PR DESCRIPTION
Commit 1: desarrollo-back: Implementar modificar cursos

Se implementó en el backend la funcionalidad completa para modificar cursos existentes en el sistema. Esta actualización en PHP permite a los administradores o usuarios autorizados editar la información de los cursos (como nombre, descripción, estado, etc.) a través de una interfaz de administración. Se añadió la lógica necesaria para recibir los datos actualizados, validarlos rigurosamente para asegurar su integridad y luego persistirlos correctamente en la base de datos, garantizando una gestión robusta de los cursos.

Commit 2: Agrega modificar y eliminar tareas

Se añadió en el backend la capacidad de modificar y eliminar tareas, completando así la gestión de estas entidades. Ahora es posible no solo actualizar los detalles de cualquier tarea (fecha límite, descripción, estado, etc.), sino también removerlas completamente del sistema cuando ya no sean necesarias. Ambas operaciones fueron desarrolladas en PHP, incluyendo validaciones para la modificación y confirmaciones de seguridad para la eliminación, asegurando que las operaciones se realicen de manera controlada y protegiendo la integridad de los datos.